### PR TITLE
Add Attachment type to preserve multipleAttachments metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export {AirtableTs} from './AirtableTs';
 export {AirtableTsError} from './AirtableTsError';
 export type {AirtableTsOptions, ScanParams, AirtableTsTable} from './types';
-export type {Item, Table} from './mapping/typeUtils';
+export type {Item, Table, Attachment} from './mapping/typeUtils';
 export type {WrappedAirtableError} from './wrapToCatchAirtableErrors';

--- a/src/mapping/fieldMappers.test.ts
+++ b/src/mapping/fieldMappers.test.ts
@@ -232,6 +232,159 @@ describe('string[]', () => {
 	});
 });
 
+describe('Attachment[]', () => {
+	test('multipleAttachments', () => {
+		const mapperPair = fieldMappers['Attachment[]']?.multipleAttachments;
+		if (!mapperPair) {
+			throw new Error('Expected mapper pair for [Attachment[], multipleAttachments]');
+		}
+
+		const fullAttachment = {
+			id: 'attXXXXXXXX',
+			url: 'https://v5.airtableusercontent.com/example',
+			filename: 'document.pdf',
+			size: 245678,
+			type: 'application/pdf',
+		};
+
+		const attachmentWithThumbnails = {
+			id: 'attYYYYYYYY',
+			url: 'https://v5.airtableusercontent.com/image',
+			filename: 'photo.jpg',
+			size: 123456,
+			type: 'image/jpeg',
+			width: 1920,
+			height: 1080,
+			thumbnails: {
+				small: {url: 'https://example.com/small', width: 36, height: 36},
+				large: {url: 'https://example.com/large', width: 512, height: 512},
+				full: {url: 'https://example.com/full', width: 1920, height: 1080},
+			},
+		};
+
+		// Full metadata is preserved
+		const result = mapperPair.fromAirtable([fullAttachment]);
+		expect(result).toEqual([{
+			id: 'attXXXXXXXX',
+			url: 'https://v5.airtableusercontent.com/example',
+			filename: 'document.pdf',
+			size: 245678,
+			type: 'application/pdf',
+		}]);
+
+		// Thumbnails and dimensions are preserved
+		const resultWithThumbs = mapperPair.fromAirtable([attachmentWithThumbnails]);
+		expect(resultWithThumbs).toEqual([{
+			id: 'attYYYYYYYY',
+			url: 'https://v5.airtableusercontent.com/image',
+			filename: 'photo.jpg',
+			size: 123456,
+			type: 'image/jpeg',
+			width: 1920,
+			height: 1080,
+			thumbnails: {
+				small: {url: 'https://example.com/small', width: 36, height: 36},
+				large: {url: 'https://example.com/large', width: 512, height: 512},
+				full: {url: 'https://example.com/full', width: 1920, height: 1080},
+			},
+		}]);
+
+		// Multiple attachments
+		expect(mapperPair.fromAirtable([fullAttachment, attachmentWithThumbnails])).toHaveLength(2);
+
+		// Null/undefined return empty array for non-nullable type
+		expect(mapperPair.fromAirtable(null)).toEqual([]);
+		expect(mapperPair.fromAirtable(undefined)).toEqual([]);
+		expect(mapperPair.fromAirtable([])).toEqual([]);
+
+		// Read-only - cannot write
+		expect(() => mapperPair.toAirtable([fullAttachment as any])).toThrow('read-only');
+	});
+
+	test('multipleAttachments handles partial data gracefully', () => {
+		const mapperPair = fieldMappers['Attachment[]']?.multipleAttachments;
+		if (!mapperPair) {
+			throw new Error('Expected mapper pair for [Attachment[], multipleAttachments]');
+		}
+
+		// Missing optional fields get defaults
+		const minimalAttachment = {
+			url: 'https://example.com/file',
+		};
+
+		const result = mapperPair.fromAirtable([minimalAttachment]);
+		expect(result).toEqual([{
+			id: '',
+			url: 'https://example.com/file',
+			filename: '',
+			size: 0,
+			type: '',
+		}]);
+
+		// Objects without url are filtered out
+		const noUrl = {id: 'att123', filename: 'test.pdf'};
+		expect(mapperPair.fromAirtable([noUrl])).toEqual([]);
+	});
+});
+
+describe('Attachment[] | null', () => {
+	test('multipleAttachments', () => {
+		const mapperPair = fieldMappers['Attachment[] | null']?.multipleAttachments;
+		if (!mapperPair) {
+			throw new Error('Expected mapper pair for [Attachment[] | null, multipleAttachments]');
+		}
+
+		const attachment = {
+			id: 'attXXXXXXXX',
+			url: 'https://v5.airtableusercontent.com/example',
+			filename: 'document.pdf',
+			size: 245678,
+			type: 'application/pdf',
+		};
+
+		// Full metadata is preserved
+		expect(mapperPair.fromAirtable([attachment])).toEqual([{
+			id: 'attXXXXXXXX',
+			url: 'https://v5.airtableusercontent.com/example',
+			filename: 'document.pdf',
+			size: 245678,
+			type: 'application/pdf',
+		}]);
+
+		// Null/undefined return null for nullable type
+		expect(mapperPair.fromAirtable(null)).toBe(null);
+		expect(mapperPair.fromAirtable(undefined)).toBe(null);
+
+		// Empty array returns empty array (not null)
+		expect(mapperPair.fromAirtable([])).toEqual([]);
+
+		// Read-only - cannot write
+		expect(() => mapperPair.toAirtable([attachment as any])).toThrow('read-only');
+	});
+});
+
+describe('string[] multipleAttachments (backward compatibility)', () => {
+	test('multipleAttachments still returns URLs only for string[] type', () => {
+		const mapperPair = fieldMappers['string[]']?.multipleAttachments;
+		if (!mapperPair) {
+			throw new Error('Expected mapper pair for [string[], multipleAttachments]');
+		}
+
+		const attachment = {
+			id: 'attXXXXXXXX',
+			url: 'https://v5.airtableusercontent.com/example',
+			filename: 'document.pdf',
+			size: 245678,
+			type: 'application/pdf',
+		};
+
+		// Only URLs are returned
+		expect(mapperPair.fromAirtable([attachment])).toEqual(['https://v5.airtableusercontent.com/example']);
+		expect(mapperPair.fromAirtable(null)).toEqual([]);
+		expect(mapperPair.fromAirtable(undefined)).toEqual([]);
+	});
+});
+
 describe('unknown', () => {
 	test.each([
 		['string', 'example'],

--- a/src/mapping/fieldMappers.ts
+++ b/src/mapping/fieldMappers.ts
@@ -1,5 +1,5 @@
 import {
-	type AirtableTypeString, type FromAirtableTypeString, type FromTsTypeString, type TsTypeString,
+	type AirtableTypeString, type FromAirtableTypeString, type FromTsTypeString, type TsTypeString, type Attachment,
 	parseType,
 } from './typeUtils';
 import {AirtableTsError, ErrorType} from '../AirtableTsError';
@@ -190,6 +190,72 @@ const multipleAttachmentsMapperPair = {
 	toAirtable: readonly('multipleAttachments'),
 	fromAirtable(obj: object[] | null | undefined) {
 		return obj?.map((v) => ('url' in v && typeof v.url === 'string' ? v.url : null!)).filter(Boolean) ?? null;
+	},
+};
+
+const multipleAttachmentsWithMetadataMapperPair = {
+	toAirtable: readonly('multipleAttachments'),
+	fromAirtable(obj: object[] | null | undefined): Attachment[] | null {
+		if (!obj) {
+			return null;
+		}
+
+		return obj
+			.filter((v): v is Record<string, unknown> =>
+				typeof v === 'object'
+				&& v !== null
+				&& 'url' in v
+				&& typeof (v as Record<string, unknown>).url === 'string')
+			.map((v) => {
+				const attachment: Attachment = {
+					id: typeof v.id === 'string' ? v.id : '',
+					url: v.url as string,
+					filename: typeof v.filename === 'string' ? v.filename : '',
+					size: typeof v.size === 'number' ? v.size : 0,
+					type: typeof v.type === 'string' ? v.type : '',
+				};
+
+				// Optional width/height for images
+				if (typeof v.width === 'number') {
+					attachment.width = v.width;
+				}
+
+				if (typeof v.height === 'number') {
+					attachment.height = v.height;
+				}
+
+				// Optional thumbnails
+				if (typeof v.thumbnails === 'object' && v.thumbnails !== null) {
+					const thumbs = v.thumbnails as Record<string, unknown>;
+					const thumbnails: Attachment['thumbnails'] = {};
+
+					for (const size of ['small', 'large', 'full'] as const) {
+						const thumb = thumbs[size];
+						if (
+							typeof thumb === 'object'
+							&& thumb !== null
+							&& 'url' in thumb
+							&& typeof (thumb as Record<string, unknown>).url === 'string'
+							&& 'width' in thumb
+							&& typeof (thumb as Record<string, unknown>).width === 'number'
+							&& 'height' in thumb
+							&& typeof (thumb as Record<string, unknown>).height === 'number'
+						) {
+							thumbnails[size] = {
+								url: (thumb as Record<string, unknown>).url as string,
+								width: (thumb as Record<string, unknown>).width as number,
+								height: (thumb as Record<string, unknown>).height as number,
+							};
+						}
+					}
+
+					if (Object.keys(thumbnails).length > 0) {
+						attachment.thumbnails = thumbnails;
+					}
+				}
+
+				return attachment;
+			});
 	},
 };
 
@@ -487,5 +553,15 @@ export const fieldMappers: Mapper = {
 				fromAirtable: (value: null) => nullablePair.fromAirtable(value) ?? [],
 			}];
 		})),
+	},
+
+	'Attachment[] | null': {
+		multipleAttachments: multipleAttachmentsWithMetadataMapperPair,
+	},
+	'Attachment[]': {
+		multipleAttachments: {
+			toAirtable: multipleAttachmentsWithMetadataMapperPair.toAirtable,
+			fromAirtable: (value: object[] | null | undefined) => multipleAttachmentsWithMetadataMapperPair.fromAirtable(value) ?? [],
+		},
 	},
 };

--- a/src/mapping/typeUtils.ts
+++ b/src/mapping/typeUtils.ts
@@ -1,5 +1,24 @@
 import {AirtableTsError, ErrorType, prependError} from '../AirtableTsError';
 
+/**
+ * Represents an attachment from Airtable with full metadata.
+ * @see https://airtable.com/developers/web/api/field-model#multipleattachment
+ */
+export type Attachment = {
+	id: string;
+	url: string;
+	filename: string;
+	size: number;
+	type: string;
+	width?: number;
+	height?: number;
+	thumbnails?: {
+		small?: {url: string; width: number; height: number};
+		large?: {url: string; width: number; height: number};
+		full?: {url: string; width: number; height: number};
+	};
+};
+
 export type TsTypeString = NonNullToString<any> | ToTsTypeString<any>;
 
 type NonNullToString<T> =
@@ -9,7 +28,8 @@ type NonNullToString<T> =
 				T extends number[] ? 'number[]' :
 					T extends string[] ? 'string[]' :
 						T extends boolean[] ? 'boolean[]' :
-							never;
+							T extends Attachment[] ? 'Attachment[]' :
+								never;
 
 export type ToTsTypeString<T> =
   null extends T ? `${NonNullToString<T>} | null` : NonNullToString<T>;
@@ -27,7 +47,9 @@ export type FromTsTypeString<T> =
 										T extends 'number[] | null' ? number[] | null :
 											T extends 'boolean[]' ? boolean[] :
 												T extends 'boolean[] | null' ? boolean[] | null :
-													never;
+													T extends 'Attachment[]' ? Attachment[] :
+														T extends 'Attachment[] | null' ? Attachment[] | null :
+															never;
 
 export type AirtableTypeString =
 	| 'aiText'
@@ -126,7 +148,7 @@ export type FromAirtableTypeString<T extends AirtableTypeString | 'unknown'> =
 									: never);
 
 type TypeDef = {
-	single: 'string' | 'number' | 'boolean';
+	single: 'string' | 'number' | 'boolean' | 'Attachment';
 	array: boolean;
 	nullable: boolean;
 };
@@ -164,6 +186,24 @@ export const parseType = (t: TsTypeString): TypeDef => {
 };
 
 /**
+ * Checks if an object is a valid Attachment
+ */
+const isAttachment = (value: unknown): value is Attachment => {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+	return (
+		typeof obj.id === 'string'
+		&& typeof obj.url === 'string'
+		&& typeof obj.filename === 'string'
+		&& typeof obj.size === 'number'
+		&& typeof obj.type === 'string'
+	);
+};
+
+/**
  * Verifies whether the given value is assignable to the given type
  *
  * @param value
@@ -180,6 +220,14 @@ export const matchesType = (value: unknown, tsType: TsTypeString): boolean => {
 
 	if (expectedType.nullable && value === null) {
 		return true;
+	}
+
+	if (expectedType.single === 'Attachment') {
+		if (!expectedType.array) {
+			return isAttachment(value);
+		}
+
+		return Array.isArray(value) && (value as unknown[]).every(isAttachment);
 	}
 
 	if (!expectedType.array && typeof value === expectedType.single) {


### PR DESCRIPTION
## Summary

Fixes #41

The `fromAirtable` mapper for `multipleAttachments` fields previously discarded all metadata (`id`, `filename`, `size`, `type`, `thumbnails`) and returned only an array of URLs.

This adds a new `Attachment` type and mappers for `'Attachment[]'` and `'Attachment[] | null'` TypeScript types that preserve all attachment metadata including optional `width`, `height`, and `thumbnails`.

The existing `string[]` mapping continues to work for backward compatibility, returning only URLs as before.

## Changes

- Added `Attachment` type with full metadata fields
- Added `'Attachment[]'` and `'Attachment[] | null'` type mappings
- Added `multipleAttachmentsWithMetadataMapperPair` mapper that preserves all metadata
- Exported `Attachment` type from index
- Added comprehensive tests for new functionality
- Verified backward compatibility with existing `string[]` mappings

## Usage

```typescript
import { Table, Attachment } from 'airtable-ts';

type MyRecord = {
  id: string;
  documents: Attachment[] | null; // Full metadata
  // or for URLs only: documents: string[] | null;
};

const table: Table<MyRecord> = {
  name: 'records',
  baseId: 'app...',
  tableId: 'tbl...',
  schema: { documents: 'Attachment[] | null' },
};
```